### PR TITLE
Release v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1550,7 +1550,7 @@ dependencies = [
 
 [[package]]
 name = "datu"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datu"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 description = "datu - a data file utility"
 license = "MIT"

--- a/features/cli.feature
+++ b/features/cli.feature
@@ -2,7 +2,7 @@ Feature: CLI
 
   Scenario: Print version
     When I run `datu --version`
-    Then the output should contain "datu 0.2.1"
+    Then the output should contain "datu 0.2.2"
 
   Scenario: Print help with help subcommand
     When I run `datu help`


### PR DESCRIPTION
Version bump from 0.2.1 to 0.2.2.

**Key changes:**
- Bump version in `Cargo.toml` and `Cargo.lock`
- Update CLI feature test to expect `datu 0.2.2` in version output

Made with [Cursor](https://cursor.com)