### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - "README.md"
       - ".github/workflows/ci.yml"
 
+permissions:
+  contents: read
+
 env:
   # We use environment variables to specify the Rust version and other settings once
   RUST_TOOLCHAIN: 1.94.0


### PR DESCRIPTION
Potential fix for [https://github.com/aisrael/datu/security/code-scanning/2](https://github.com/aisrael/datu/security/code-scanning/2)

To fix this, add an explicit `permissions` block in `.github/workflows/ci.yml`. The best minimal fix without changing functionality is to set workflow-level permissions to read-only for contents, since all jobs here are CI checks and only need repository read access (including `actions/checkout`).

Apply this near the top-level keys (e.g., after `on:` and before `env:`), so it applies to all jobs unless overridden later. No imports, methods, or dependencies are needed—just YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
