### PR TITLE
Allow head/tail/sample to write to an output file

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,15 +231,19 @@ datu count data.csv --input-headers=false
 
 ### `sample`
 
-Print N randomly sampled rows from a Parquet, Avro, CSV, or ORC file to stdout (default CSV; use `--output` for other formats). For Parquet and ORC, sampling uses file metadata to determine total row count and selects random indices; for Avro and CSV, reservoir sampling is used.
+Print N randomly sampled rows from a Parquet, Avro, CSV, or ORC file to stdout (default CSV; use `--output` for other formats), or write them to a file by supplying an optional `OUTPUT` path. For Parquet and ORC, sampling uses file metadata to determine total row count and selects random indices; for Avro and CSV, reservoir sampling is used.
 
 **Supported input formats:** Parquet (`.parquet`, `.parq`), Avro (`.avro`), CSV (`.csv`), ORC (`.orc`).
+
+**Supported output formats (when writing to a file):** CSV (`.csv`), JSON (`.json`), YAML (`.yaml`), Parquet (`.parquet`, `.parq`), Avro (`.avro`), ORC (`.orc`), XLSX (`.xlsx`).
 
 **Usage (CLI):**
 
 ```sh
-datu sample <INPUT> [OPTIONS]
+datu sample <INPUT> [OUTPUT] [OPTIONS]
 ```
+
+When `OUTPUT` is omitted, rows are printed to stdout and `--output` selects the display format. When `OUTPUT` is provided, rows are written to that file and the format is inferred from its extension (or `-O`/`--output-type`).
 
 **Usage (REPL):**
 
@@ -255,7 +259,9 @@ Prints _n_ random rows to stdout. Chain `|> write("out.csv")` to write to a file
 |--------|-------------|
 | `-I`, `--input <TYPE>` | Input file type (`avro`, `csv`, `json`, `orc`, `parquet`, `xlsx`, `yaml`). Overrides extension-based detection. |
 | `-n`, `--number <N>` | Number of rows to sample. Default: 10. |
-| `--output <FORMAT>` | Output format: `csv`, `json`, `json-pretty`, or `yaml`. Case insensitive. Default: `csv`. |
+| `--output <FORMAT>` | Display format when printing to stdout: `csv`, `json`, `json-pretty`, or `yaml`. Case insensitive. Default: `csv`. Cannot be combined with an `OUTPUT` file. |
+| `-O`, `--output-type <TYPE>` | Output file type when writing to a file (`avro`, `csv`, `json`, `orc`, `parquet`, `xlsx`, `yaml`). Overrides extension-based detection. |
+| `--json-pretty` | When writing JSON to a file, format output with indentation and newlines. Ignored for other output formats. |
 | `--sparse` | For JSON/YAML: omit keys with null/missing values. Default: `true`. Use `--sparse=false` to include default values. |
 | `--select <COLUMNS>...` | Columns to include. If not specified, all columns are printed. Same format as `convert --select`. |
 | `--input-headers [BOOL]` | For CSV input: whether the first row is a header. Default: `true` when omitted. Use `--input-headers=false` for headerless CSV. |
@@ -274,21 +280,29 @@ datu sample data.orc --number 5
 
 # 20 random rows, specific columns
 datu sample data.parquet -n 20 --select id,name,email
+
+# Write a random sample to a file (format from extension)
+datu sample input.parquet output.avro -n 5
+datu sample data.parquet sample.csv -n 100
 ```
 
 ---
 
 ### `head`
 
-Print the first N rows of a Parquet, Avro, CSV, or ORC file to stdout (default CSV; use `--output` for other formats).
+Print the first N rows of a Parquet, Avro, CSV, or ORC file to stdout (default CSV; use `--output` for other formats), or write them to a file by supplying an optional `OUTPUT` path.
 
 **Supported input formats:** Parquet (`.parquet`, `.parq`), Avro (`.avro`), CSV (`.csv`), ORC (`.orc`).
+
+**Supported output formats (when writing to a file):** CSV (`.csv`), JSON (`.json`), YAML (`.yaml`), Parquet (`.parquet`, `.parq`), Avro (`.avro`), ORC (`.orc`), XLSX (`.xlsx`).
 
 **Usage (CLI):**
 
 ```sh
-datu head <INPUT> [OPTIONS]
+datu head <INPUT> [OUTPUT] [OPTIONS]
 ```
+
+When `OUTPUT` is omitted, rows are printed to stdout and `--output` selects the display format. When `OUTPUT` is provided, rows are written to that file and the format is inferred from its extension (or `-O`/`--output-type`).
 
 **Usage (REPL):**
 
@@ -304,7 +318,9 @@ Prints the first _n_ rows to stdout. Chain `|> write("out.csv")` to write to a f
 |--------|-------------|
 | `-I`, `--input <TYPE>` | Input file type (`avro`, `csv`, `json`, `orc`, `parquet`, `xlsx`, `yaml`). Overrides extension-based detection. |
 | `-n`, `--number <N>` | Number of rows to print. Default: 10. |
-| `--output <FORMAT>` | Output format: `csv`, `json`, `json-pretty`, or `yaml`. Case insensitive. Default: `csv`. |
+| `--output <FORMAT>` | Display format when printing to stdout: `csv`, `json`, `json-pretty`, or `yaml`. Case insensitive. Default: `csv`. Cannot be combined with an `OUTPUT` file. |
+| `-O`, `--output-type <TYPE>` | Output file type when writing to a file (`avro`, `csv`, `json`, `orc`, `parquet`, `xlsx`, `yaml`). Overrides extension-based detection. |
+| `--json-pretty` | When writing JSON to a file, format output with indentation and newlines. Ignored for other output formats. |
 | `--sparse` | For JSON/YAML: omit keys with null/missing values. Default: `true`. Use `--sparse=false` to include default values. |
 | `--select <COLUMNS>...` | Columns to include. If not specified, all columns are printed. Same format as `convert --select`. |
 | `--input-headers [BOOL]` | For CSV input: whether the first row is a header. Default: `true` when omitted. Use `--input-headers=false` for headerless CSV. |
@@ -326,23 +342,31 @@ datu head data.parquet -n 20 --select id,name,email
 
 # Head from a headerless CSV file
 datu head data.csv --input-headers=false
+
+# Write the first N rows to a file (format from extension)
+datu head data.parquet first100.csv -n 100
+datu head data.parquet first10.avro -n 10
 ```
 
 ---
 
 ### `tail`
 
-Print the last N rows of a Parquet, Avro, CSV, or ORC file to stdout (default CSV; use `--output` for other formats).
+Print the last N rows of a Parquet, Avro, CSV, or ORC file to stdout (default CSV; use `--output` for other formats), or write them to a file by supplying an optional `OUTPUT` path.
 
 **Supported input formats:** Parquet (`.parquet`, `.parq`), Avro (`.avro`), CSV (`.csv`), ORC (`.orc`).
+
+**Supported output formats (when writing to a file):** CSV (`.csv`), JSON (`.json`), YAML (`.yaml`), Parquet (`.parquet`, `.parq`), Avro (`.avro`), ORC (`.orc`), XLSX (`.xlsx`).
 
 > **Note:** For Avro and CSV files, `tail` requires a full file scan since these formats do not support random access to the end of the file.
 
 **Usage (CLI):**
 
 ```sh
-datu tail <INPUT> [OPTIONS]
+datu tail <INPUT> [OUTPUT] [OPTIONS]
 ```
+
+When `OUTPUT` is omitted, rows are printed to stdout and `--output` selects the display format. When `OUTPUT` is provided, rows are written to that file and the format is inferred from its extension (or `-O`/`--output-type`).
 
 **Usage (REPL):**
 
@@ -356,7 +380,9 @@ datu tail <INPUT> [OPTIONS]
 |--------|-------------|
 | `-I`, `--input <TYPE>` | Input file type (`avro`, `csv`, `json`, `orc`, `parquet`, `xlsx`, `yaml`). Overrides extension-based detection. |
 | `-n`, `--number <N>` | Number of rows to print. Default: 10. |
-| `--output <FORMAT>` | Output format: `csv`, `json`, `json-pretty`, or `yaml`. Case insensitive. Default: `csv`. |
+| `--output <FORMAT>` | Display format when printing to stdout: `csv`, `json`, `json-pretty`, or `yaml`. Case insensitive. Default: `csv`. Cannot be combined with an `OUTPUT` file. |
+| `-O`, `--output-type <TYPE>` | Output file type when writing to a file (`avro`, `csv`, `json`, `orc`, `parquet`, `xlsx`, `yaml`). Overrides extension-based detection. |
+| `--json-pretty` | When writing JSON to a file, format output with indentation and newlines. Ignored for other output formats. |
 | `--sparse` | For JSON/YAML: omit keys with null/missing values. Default: `true`. Use `--sparse=false` to include default values. |
 | `--select <COLUMNS>...` | Columns to include. If not specified, all columns are printed. Same format as `convert --select`. |
 | `--input-headers [BOOL]` | For CSV input: whether the first row is a header. Default: `true` when omitted. Use `--input-headers=false` for headerless CSV. |
@@ -376,8 +402,9 @@ datu tail data.orc --number 50
 # Last 20 rows, specific columns
 datu tail data.parquet -n 20 --select id,name,email
 
-# Redirect tail output to a file
-datu tail data.parquet -n 1000 > last1000.csv
+# Write the last N rows to a file (format from extension)
+datu tail data.parquet last1000.csv -n 1000
+datu tail data.parquet last10.parquet -n 10
 ```
 
 ---

--- a/features/cli/head.feature
+++ b/features/cli/head.feature
@@ -156,3 +156,20 @@ Feature: Head
     And the output should be valid YAML
     And the output should contain "first_name"
     And the output should contain "email"
+
+  Scenario: Head Parquet to CSV file
+    Given a file "fixtures/table.parquet"
+    When I run `datu head fixtures/table.parquet $TEMPDIR/head.csv -n 2`
+    Then the command should succeed
+    And the output should contain "Wrote head of fixtures/table.parquet to $TEMPDIR/head.csv"
+    And the file "$TEMPDIR/head.csv" should exist
+    And the first line of that file should contain "one,two"
+    And that file should have 3 lines
+
+  Scenario: Head Parquet to Avro file
+    Given a file "fixtures/table.parquet"
+    When I run `datu head fixtures/table.parquet $TEMPDIR/head.avro -n 2`
+    Then the command should succeed
+    And the output should contain "Wrote head of fixtures/table.parquet to $TEMPDIR/head.avro"
+    And the file "$TEMPDIR/head.avro" should exist
+    And that file should have 2 records

--- a/features/cli/sample.feature
+++ b/features/cli/sample.feature
@@ -1,0 +1,44 @@
+Feature: Sample
+  Print or write N randomly sampled rows from a Parquet, Avro, CSV, JSON, or ORC file.
+
+  Scenario: Sample Parquet to stdout (default 10 lines)
+    When I run `datu sample fixtures/table.parquet`
+    Then the command should succeed
+    And the output should contain "one"
+
+  Scenario: Sample Parquet to stdout with -n 2
+    When I run `datu sample fixtures/table.parquet -n 2`
+    Then the command should succeed
+    And the output should have a header and 2 lines
+
+  Scenario: Sample Parquet to Avro file
+    Given a file "fixtures/table.parquet"
+    When I run `datu sample fixtures/table.parquet $TEMPDIR/sample.avro -n 2`
+    Then the command should succeed
+    And the output should contain "Sampled fixtures/table.parquet to $TEMPDIR/sample.avro"
+    And the file "$TEMPDIR/sample.avro" should exist
+    And that file should have 2 records
+
+  Scenario: Sample Parquet to CSV file
+    Given a file "fixtures/table.parquet"
+    When I run `datu sample fixtures/table.parquet $TEMPDIR/sample.csv -n 2`
+    Then the command should succeed
+    And the output should contain "Sampled fixtures/table.parquet to $TEMPDIR/sample.csv"
+    And the file "$TEMPDIR/sample.csv" should exist
+    And that file should have 3 lines
+
+  Scenario: Sample Avro to Parquet file
+    Given a file "fixtures/userdata5.avro"
+    When I run `datu sample fixtures/userdata5.avro $TEMPDIR/sample.parquet -n 5`
+    Then the command should succeed
+    And the output should contain "Sampled fixtures/userdata5.avro to $TEMPDIR/sample.parquet"
+    And the file "$TEMPDIR/sample.parquet" should exist
+    And that file should be a valid Parquet file
+    And that file should have 5 records
+
+  Scenario: Sample with -O overrides output type
+    Given a file "fixtures/table.parquet"
+    When I run `datu sample fixtures/table.parquet $TEMPDIR/sample_out -n 2 -O csv`
+    Then the command should succeed
+    And the file "$TEMPDIR/sample_out" should exist
+    And that file should have 3 lines

--- a/features/cli/sample.feature
+++ b/features/cli/sample.feature
@@ -38,7 +38,8 @@ Feature: Sample
 
   Scenario: Sample with -O overrides output type
     Given a file "fixtures/table.parquet"
-    When I run `datu sample fixtures/table.parquet $TEMPDIR/sample_out -n 2 -O csv`
+    When I run `datu sample fixtures/table.parquet $TEMPDIR/sample.out -n 2 -O json`
     Then the command should succeed
-    And the file "$TEMPDIR/sample_out" should exist
-    And that file should have 3 lines
+    And the output should contain "Sampled fixtures/table.parquet to $TEMPDIR/sample.out"
+    And the file "$TEMPDIR/sample.out" should exist
+    And the file "$TEMPDIR/sample.out" should be valid JSON

--- a/features/cli/tail.feature
+++ b/features/cli/tail.feature
@@ -147,3 +147,21 @@ Feature: Tail
     And the output should be valid YAML
     And the output should contain "id"
     And the output should contain "email"
+
+  Scenario: Tail Parquet to CSV file
+    Given a file "fixtures/table.parquet"
+    When I run `datu tail fixtures/table.parquet $TEMPDIR/tail.csv -n 2`
+    Then the command should succeed
+    And the output should contain "Wrote tail of fixtures/table.parquet to $TEMPDIR/tail.csv"
+    And the file "$TEMPDIR/tail.csv" should exist
+    And the first line of that file should contain "one,two"
+    And that file should have 3 lines
+
+  Scenario: Tail Avro to Parquet file
+    Given a file "fixtures/userdata5.avro"
+    When I run `datu tail fixtures/userdata5.avro $TEMPDIR/tail.parquet -n 5`
+    Then the command should succeed
+    And the output should contain "Wrote tail of fixtures/userdata5.avro to $TEMPDIR/tail.parquet"
+    And the file "$TEMPDIR/tail.parquet" should exist
+    And that file should be a valid Parquet file
+    And that file should have 5 records

--- a/src/bin/datu/commands/heads_or_tails.rs
+++ b/src/bin/datu/commands/heads_or_tails.rs
@@ -1,6 +1,7 @@
 //! head, tail, and sample CLI commands share the same pipeline setup.
 
 use datu::DISPLAY_PIPELINE_INPUTS_FOR_CLI;
+use datu::cli::DisplayOutputFormat;
 use datu::cli::HeadsOrTails;
 use datu::pipeline::PipelineBuilder;
 use datu::pipeline::SelectSpec;
@@ -24,18 +25,19 @@ impl HeadsOrTailsCmd {
             Self::Sample => "sample",
         }
     }
+
+    /// Past-tense verb used in the success message when writing to a file.
+    fn write_verb(self) -> &'static str {
+        match self {
+            Self::Head => "Wrote head of",
+            Self::Tail => "Wrote tail of",
+            Self::Sample => "Sampled",
+        }
+    }
 }
 
 /// head, tail, or sample: print or sample rows from supported pipeline input formats.
 pub async fn heads_or_tails(args: HeadsOrTails, cmd: HeadsOrTailsCmd) -> Result<()> {
-    let input_file_type = resolve_file_type(args.input, &args.input_path)?;
-    if !input_file_type.supports_pipeline_display_input() {
-        bail!(
-            "Only {DISPLAY_PIPELINE_INPUTS_FOR_CLI} are supported for {}",
-            cmd.name()
-        );
-    }
-
     let mut builder = PipelineBuilder::new();
     builder.read(&args.input_path).input_type(args.input);
     match cmd {
@@ -51,13 +53,53 @@ pub async fn heads_or_tails(args: HeadsOrTails, cmd: HeadsOrTailsCmd) -> Result<
     }
     builder
         .csv_has_header(args.input_headers)
-        .sparse(args.sparse)
-        .display_format(args.output)
-        .display_csv_headers(args.output_headers.unwrap_or(true));
+        .sparse(args.sparse);
 
     if let Some(spec) = SelectSpec::from_cli_args(&args.select) {
         builder.select_spec(spec);
     }
+
+    if let Some(output_path) = &args.output_path {
+        // Writing to a file: the format comes from the OUTPUT extension (or -O), so the
+        // stdout-only display flags would be silently ignored. Reject them explicitly.
+        if args.output != DisplayOutputFormat::Csv {
+            bail!(
+                "--output (stdout display format) cannot be combined with an output file; the file format is determined by the OUTPUT extension or -O/--output-type"
+            );
+        }
+        if args.output_headers == Some(false) {
+            bail!(
+                "--output-headers only applies when printing to stdout, not when writing to a file"
+            );
+        }
+
+        builder
+            .write(output_path)
+            .output_type(args.output_type)
+            .json_pretty(args.json_pretty);
+
+        let mut pipeline = builder.build()?;
+        pipeline.execute()?;
+        eprintln!(
+            "{verb} {input} to {output}",
+            verb = cmd.write_verb(),
+            input = args.input_path,
+            output = output_path
+        );
+        return Ok(());
+    }
+
+    let input_file_type = resolve_file_type(args.input, &args.input_path)?;
+    if !input_file_type.supports_pipeline_display_input() {
+        bail!(
+            "Only {DISPLAY_PIPELINE_INPUTS_FOR_CLI} are supported for {}",
+            cmd.name()
+        );
+    }
+
+    builder
+        .display_format(args.output)
+        .display_csv_headers(args.output_headers.unwrap_or(true));
 
     let mut pipeline = builder.build()?;
     Ok(pipeline.execute()?)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -116,6 +116,8 @@ pub struct CountArgs {
 pub struct HeadsOrTails {
     /// Path to the Parquet, Avro, ORC, or CSV file
     pub input_path: String,
+    /// Optional path to an output file. When omitted, rows are printed to stdout.
+    pub output_path: Option<String>,
     #[arg(
         long,
         short = 'I',
@@ -135,9 +137,21 @@ pub struct HeadsOrTails {
         short,
         default_value_t = DisplayOutputFormat::Csv,
         value_parser = clap::value_parser!(DisplayOutputFormat),
-        help = "Output format: csv, json, json-pretty, or yaml"
+        help = "Output format when printing to stdout: csv, json, json-pretty, or yaml"
     )]
     pub output: DisplayOutputFormat,
+    #[arg(
+        long = "output-type",
+        short = 'O',
+        value_parser = clap::value_parser!(FileType),
+        help = "Output file type when writing to a file (avro, csv, json, orc, parquet, xlsx, yaml). Overrides extension-based detection."
+    )]
+    pub output_type: Option<FileType>,
+    #[arg(
+        long,
+        help = "When writing JSON to a file, format output with indentation and newlines. Ignored for other output formats."
+    )]
+    pub json_pretty: bool,
     #[arg(
         long,
         default_value_t = true,


### PR DESCRIPTION
## Summary

Adds an optional `OUTPUT` positional argument to the `head`, `tail`, and `sample` CLI commands so sliced/sampled rows can be written directly to a file instead of only being printed to stdout:

```sh
datu sample input.parquet output.avro -n 5
datu head data.parquet first100.csv -n 100
datu tail data.parquet last10.parquet -n 10
```

This mirrors `convert`: the output format is inferred from the file extension, or overridden with `-O`/`--output-type`. When `OUTPUT` is omitted, the existing stdout display behavior is unchanged. The underlying pipeline (`read -> head/tail/sample -> write`) was already supported by `PipelineBuilder`; this change only wires it up at the CLI layer.

## Key changes

- `src/cli.rs`: extend `HeadsOrTails` with an optional `output_path` positional, a `-O`/`--output-type` file-type override, and `--json-pretty`. The existing `-o`/`--output` flag keeps selecting the stdout display format.
- `src/bin/datu/commands/heads_or_tails.rs`: branch on `output_path` — write to a file (`.write()`/`.output_type()`/`.json_pretty()`) with a `convert`-style success message, or fall back to the stdout display path. Stdout-only display flags (`--output` non-default, `--output-headers=false`) are rejected when an output file is given.
- `features/cli/sample.feature` (new) plus file-output scenarios in `head.feature`/`tail.feature`.
- `README.md`: document the optional `OUTPUT` positional, the `-O`/`--output-type` and `--json-pretty` options, and add examples for all three commands.

## Test plan

- [x] `cargo +nightly fmt`
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] `cargo test --lib` (163 passed) and `cargo test --bins` (12 passed)
- [x] Manual smoke tests: `sample`/`head` to Avro/CSV/Parquet files (verified row counts), stdout path unchanged, and rejection of `--output <fmt>` combined with an output file
- [ ] `cargo test --test cli` (cucumber CLI suite) — could not be run to completion in the local sandbox (the cucumber runner busy-loops even on pre-existing scenarios in this environment); new scenarios follow the existing patterns and should be validated in CI

Made with [Cursor](https://cursor.com)