### PR TITLE
Release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # datu Version Notes
 
+## v0.3.5
+
+### Highlights
+
+- **Diff command**: New `datu diff` compares two files with `--max-diffs` early exit.
+- **Head/tail/sample output**: `head`, `tail`, and `sample` can write results to an output file.
+- **REPL aggregates**: Added `count` and `count_distinct`; SQL `filter()` with `WHERE`/`HAVING`, `FilterSpec`, and dual straddling filters.
+- **Docs**: README and REPL documentation expanded for new commands and filtering.
+
+### Improvements
+
+- **CLI**
+  - Diff command with Cucumber coverage and Avro fixtures.
+  - Head, tail, and sample commands accept an output path.
+
+- **REPL**
+  - Filter planning and stage execution for SQL-style predicates.
+  - Aggregate test coverage extended.
+
+- **Tooling**
+  - CI workflow permissions tightened.
+  - Dependency updates (`rand` 0.9).
+
+### Changelog Stats
+
+- 7 commits
+- 31 files changed
+- 1555 insertions
+- 98 deletions
+
 ## v0.3.4
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "datu"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "arrow",
  "arrow-avro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datu"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2024"
 description = "datu - a data file utility"
 license = "MIT"

--- a/features/cli/cli.feature
+++ b/features/cli/cli.feature
@@ -2,7 +2,7 @@ Feature: CLI
 
   Scenario: Print version
     When I run `datu --version`
-    Then the first line of the output should be: datu 0.3.4
+    Then the first line of the output should be: datu 0.3.5
 
   Scenario: Print help with help subcommand
     When I run `datu help`


### PR DESCRIPTION
## Summary

Prepares release **v0.3.5** with version bump, changelog, and CLI version test update.

See the new [CHANGELOG section for v0.3.5](https://github.com/aisrael/datu/blob/release/0.3.5/CHANGELOG.md#v035) for highlights:

- **Diff command** — new `datu diff` with `--max-diffs` early exit
- **Head/tail/sample output** — commands can write to an output file
- **REPL** — `count`/`count_distinct` aggregates; SQL `filter()` with WHERE/HAVING
- **Docs** — README and REPL documentation updates

## Changelog stats (since v0.3.4)

- 7 commits
- 31 files changed, 1555 insertions, 98 deletions

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`

Full diff vs `main`: https://github.com/aisrael/datu/compare/main...release/0.3.5


Made with [Cursor](https://cursor.com)