### PR TITLE
Rename datu diff --max-diffs to --limit (v0.3.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # datu Version Notes
 
+## v0.3.6
+
+### Highlights
+
+- **Diff command**: Renamed `--max-diffs` to `--limit` for consistency with other commands. `--max-diffs` remains supported but is deprecated.
+
+### Improvements
+
+- **CLI**
+  - `datu diff` uses `--limit` instead of `--max-diffs`; the old flag prints a deprecation warning.
+  - README and Cucumber coverage updated for the new flag.
+
 ## v0.3.5
 
 ### Highlights

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "datu"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "arrow",
  "arrow-avro",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datu"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2024"
 description = "datu - a data file utility"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ datu diff <FILE1> <FILE2> [OPTIONS]
 | Option | Description |
 |--------|-------------|
 | `-I`, `--input <TYPE>` | Input file type (`avro`, `csv`, `json`, `orc`, `parquet`). Applied to both files; overrides extension-based detection. |
-| `--max-diffs <N>` | Maximum total differing rows to display (file1 + file2 combined). Default: `100`. Use `0` for unlimited. |
+| `--limit <N>` | Maximum total differing rows to display (file1 + file2 combined). Default: `100`. Use `0` for unlimited. |
 
 **Output:**
 
@@ -256,9 +256,9 @@ datu diff <FILE1> <FILE2> [OPTIONS]
 - Otherwise, rows present only in `FILE1` and rows present only in `FILE2` are each printed in tab-separated format with a header line of column names.
 - Schema-only differences (columns not shared between both files) are reported on stderr before the row comparison output.
 
-> **Note on `--max-diffs`:** The two files are streamed and compared row-by-row, and the scan stops early as soon as the running diff count reaches the limit — without reading either file to the end (except JSON, which is buffered fully before comparison). Because the comparison is incomplete when it stops early, some reported rows may be **false positives**: a row counted as unique to one file might have been cancelled out by a matching row later in the other file. Use `--max-diffs 0` to disable the limit and get an exact, complete comparison.
+> **Note on `--limit`:** The two files are streamed and compared row-by-row, and the scan stops early as soon as the running diff count reaches the limit — without reading either file to the end (except JSON, which is buffered fully before comparison). Because the comparison is incomplete when it stops early, some reported rows may be **false positives**: a row counted as unique to one file might have been cancelled out by a matching row later in the other file. Use `--limit 0` to disable the limit and get an exact, complete comparison.
 >
-> **Note on `--max-diffs 0`:** Disabling the limit forces both files to be read in full and every distinct row to be held in memory. On extremely large inputs this can take a very long time and/or exhaust available memory. Prefer a bounded `--max-diffs` value when working with large files.
+> **Note on `--limit 0`:** Disabling the limit forces both files to be read in full and every distinct row to be held in memory. On extremely large inputs this can take a very long time and/or exhaust available memory. Prefer a bounded `--limit` value when working with large files.
 
 **Examples:**
 

--- a/features/cli/cli.feature
+++ b/features/cli/cli.feature
@@ -2,7 +2,7 @@ Feature: CLI
 
   Scenario: Print version
     When I run `datu --version`
-    Then the first line of the output should be: datu 0.3.5
+    Then the first line of the output should be: datu 0.3.6
 
   Scenario: Print help with help subcommand
     When I run `datu help`

--- a/features/cli/diff.feature
+++ b/features/cli/diff.feature
@@ -25,21 +25,30 @@ Feature: Diff
     Then the command should fail
     And the output should contain "different formats"
 
-  Scenario: --max-diffs truncates output when limit is exceeded
+  Scenario: --limit truncates output when limit is exceeded
+    Given a file "fixtures/file1.avro"
+    And a file "fixtures/file2.avro"
+    When I run `datu diff fixtures/file1.avro fixtures/file2.avro --limit 1`
+    Then the command should succeed
+    And the output should contain "output truncated at 1 diffs"
+    And the output should contain "--limit"
+
+  Scenario: --limit 0 disables the limit
+    Given a file "fixtures/file1.avro"
+    And a file "fixtures/file2.avro"
+    When I run `datu diff fixtures/file1.avro fixtures/file2.avro --limit 0`
+    Then the command should succeed
+    And the output should contain "foo"
+    And the output should contain "fizz"
+
+  Scenario: --max-diffs is deprecated but still works
     Given a file "fixtures/file1.avro"
     And a file "fixtures/file2.avro"
     When I run `datu diff fixtures/file1.avro fixtures/file2.avro --max-diffs 1`
     Then the command should succeed
+    And the output should contain "Warning: `--max-diffs` is deprecated"
+    And the output should contain "use `--limit` instead"
     And the output should contain "output truncated at 1 diffs"
-    And the output should contain "--max-diffs"
-
-  Scenario: --max-diffs 0 disables the limit
-    Given a file "fixtures/file1.avro"
-    And a file "fixtures/file2.avro"
-    When I run `datu diff fixtures/file1.avro fixtures/file2.avro --max-diffs 0`
-    Then the command should succeed
-    And the output should contain "foo"
-    And the output should contain "fizz"
 
   Scenario: Identical files with explicit --input override
     Given a file "fixtures/file1.avro"

--- a/src/bin/datu/commands/diff.rs
+++ b/src/bin/datu/commands/diff.rs
@@ -36,7 +36,22 @@ pub struct DiffArgs {
         default_value_t = 100,
         help = "Maximum total differing rows to display (file1 + file2 combined). Use 0 for unlimited."
     )]
-    pub max_diffs: usize,
+    pub limit: usize,
+    #[arg(long = "max-diffs", alias = "max-diff", hide = true)]
+    pub max_diffs: Option<usize>,
+}
+
+impl DiffArgs {
+    fn effective_limit(&self) -> usize {
+        if let Some(max_diffs) = self.max_diffs {
+            eprintln!(
+                "Warning: `--max-diffs` is deprecated; use `--limit` instead. `--max-diffs` may be removed in a future version."
+            );
+            max_diffs
+        } else {
+            self.limit
+        }
+    }
 }
 
 /// Opens a lazy `RecordBatchReader` without loading all rows into memory.
@@ -187,8 +202,9 @@ pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
     //
     // When we stop early the map is partial, so some diffs may be false positives
     // (rows that would cancel if more of the other file were read). This is acceptable:
-    // the caller controls tolerance via --max-diffs.
-    let unlimited = args.max_diffs == 0;
+    // the caller controls tolerance via --limit.
+    let limit = args.effective_limit();
+    let unlimited = limit == 0;
     let mut counts: HashMap<String, (i64, i64)> = HashMap::new();
     let mut running_diffs: i64 = 0;
     let mut truncated = false;
@@ -212,7 +228,7 @@ pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
                     running_diffs -= 1;
                 }
                 entry.0 += 1;
-                if !unlimited && running_diffs >= args.max_diffs as i64 {
+                if !unlimited && running_diffs >= limit as i64 {
                     truncated = true;
                     break 'scan;
                 }
@@ -235,7 +251,7 @@ pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
                     running_diffs -= 1;
                 }
                 entry.1 += 1;
-                if !unlimited && running_diffs >= args.max_diffs as i64 {
+                if !unlimited && running_diffs >= limit as i64 {
                     truncated = true;
                     break 'scan;
                 }
@@ -301,10 +317,7 @@ pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
 
         if truncated {
             println!();
-            println!(
-                "(output truncated at {} diffs; use --max-diffs to increase the limit)",
-                args.max_diffs
-            );
+            println!("(output truncated at {limit} diffs; use --limit to increase the limit)");
         }
     }
 
@@ -320,7 +333,8 @@ mod tests {
             file1: file1.to_string(),
             file2: file2.to_string(),
             input: None,
-            max_diffs: 100,
+            limit: 100,
+            max_diffs: None,
         }
     }
 
@@ -352,10 +366,10 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_diff_max_diffs_truncates() {
-        // file1 and file2 have 2 total differing rows; max_diffs=1 forces early exit
+    async fn test_diff_limit_truncates() {
+        // file1 and file2 have 2 total differing rows; limit=1 forces early exit
         let args = DiffArgs {
-            max_diffs: 1,
+            limit: 1,
             ..make_args("fixtures/file1.avro", "fixtures/file2.avro")
         };
         let result = diff(args).await;
@@ -363,12 +377,28 @@ mod tests {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_diff_max_diffs_zero_is_unlimited() {
+    async fn test_diff_limit_zero_is_unlimited() {
         let args = DiffArgs {
-            max_diffs: 0,
+            limit: 0,
             ..make_args("fixtures/file1.avro", "fixtures/file2.avro")
         };
         let result = diff(args).await;
         assert!(result.is_ok(), "diff failed: {:?}", result.err());
+    }
+
+    #[test]
+    fn test_effective_limit_uses_limit_by_default() {
+        let args = make_args("a", "b");
+        assert_eq!(args.effective_limit(), 100);
+    }
+
+    #[test]
+    fn test_effective_limit_prefers_deprecated_max_diffs() {
+        let args = DiffArgs {
+            limit: 100,
+            max_diffs: Some(5),
+            ..make_args("a", "b")
+        };
+        assert_eq!(args.effective_limit(), 5);
     }
 }


### PR DESCRIPTION
## Summary
- Renames `datu diff --max-diffs` to `--limit` for consistency with `convert`, `head`, `tail`, and other commands.
- Keeps `--max-diffs` (and `--max-diff`) as deprecated aliases that print a warning and may be removed in a future version.
- Bumps version to 0.3.6 and updates README, CHANGELOG, and Cucumber/unit tests.

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`
- [ ] Verify `datu diff file1 file2 --limit 1` truncates output and mentions `--limit`
- [ ] Verify `datu diff file1 file2 --max-diffs 1` still works and prints deprecation warning


Made with [Cursor](https://cursor.com)