### PR TITLE
Add JSON output to datu diff

### DIFF
--- a/features/cli/diff.feature
+++ b/features/cli/diff.feature
@@ -55,3 +55,29 @@ Feature: Diff
     When I run `datu diff fixtures/file1.avro fixtures/file1.avro --input avro`
     Then the command should succeed
     And the output should contain "Files are identical (4 rows)"
+
+  Scenario: Identical Avro files with --json
+    Given a file "fixtures/file1.avro"
+    When I run `datu diff fixtures/file1.avro fixtures/file1.avro --json`
+    Then the command should succeed
+    And the output should be valid JSON
+    And the output should contain "identical"
+    And the output should contain "row_count"
+
+  Scenario: Differing Avro files with --output json
+    Given a file "fixtures/file1.avro"
+    And a file "fixtures/file2.avro"
+    When I run `datu diff fixtures/file1.avro fixtures/file2.avro --output json`
+    Then the command should succeed
+    And the output should be valid JSON
+    And the output should contain "only_in_file2"
+    And the output should contain "foo"
+    And the output should contain "fizz"
+
+  Scenario: Differing Avro files with -o json
+    Given a file "fixtures/file1.avro"
+    And a file "fixtures/file2.avro"
+    When I run `datu diff fixtures/file1.avro fixtures/file2.avro -o json`
+    Then the command should succeed
+    And the output should be valid JSON
+    And the output should contain "email"

--- a/src/bin/datu/commands/diff.rs
+++ b/src/bin/datu/commands/diff.rs
@@ -1,6 +1,7 @@
 //! `datu diff` — compare two data files row-by-row
 
 use std::collections::HashMap;
+use std::str::FromStr;
 
 use arrow::array::RecordBatchReader;
 use arrow::record_batch::RecordBatch;
@@ -16,6 +17,34 @@ use datu::pipeline::read::ReadResult;
 use datu::pipeline::read::read_to_dataframe;
 use datu::resolve_file_type;
 use eyre::bail;
+use serde::Serialize;
+
+/// Output format for the `datu diff` command.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum DiffOutputFormat {
+    #[default]
+    Text,
+    Json,
+}
+
+impl TryFrom<&str> for DiffOutputFormat {
+    type Error = String;
+
+    fn try_from(s: &str) -> Result<Self, Self::Error> {
+        match s.to_lowercase().as_str() {
+            "json" => Ok(DiffOutputFormat::Json),
+            _ => Err(format!("unknown output type '{s}', expected json")),
+        }
+    }
+}
+
+impl FromStr for DiffOutputFormat {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::try_from(s)
+    }
+}
 
 /// Arguments for the `datu diff` command.
 #[derive(Args)]
@@ -39,6 +68,15 @@ pub struct DiffArgs {
     pub limit: usize,
     #[arg(long = "max-diffs", alias = "max-diff", hide = true)]
     pub max_diffs: Option<usize>,
+    #[arg(long, help = "Emit diff results as JSON")]
+    pub json: bool,
+    #[arg(
+        long,
+        short,
+        value_parser = clap::value_parser!(DiffOutputFormat),
+        help = "Output format: json"
+    )]
+    pub output: Option<DiffOutputFormat>,
 }
 
 impl DiffArgs {
@@ -52,6 +90,210 @@ impl DiffArgs {
             self.limit
         }
     }
+
+    fn output_format(&self) -> DiffOutputFormat {
+        if self.json {
+            return DiffOutputFormat::Json;
+        }
+        self.output.unwrap_or(DiffOutputFormat::Text)
+    }
+}
+
+/// Aggregated diff results used for text and JSON rendering.
+struct DiffReport {
+    file1: String,
+    file2: String,
+    identical: bool,
+    row_count: Option<usize>,
+    columns: Vec<String>,
+    schema_only_in_file1: Vec<(String, String)>,
+    schema_only_in_file2: Vec<(String, String)>,
+    only_in_file1: Vec<String>,
+    only_in_file2: Vec<String>,
+    truncated: bool,
+    limit: usize,
+}
+
+#[derive(Serialize)]
+struct SchemaColumnJson {
+    name: String,
+    data_type: String,
+}
+
+#[derive(Serialize)]
+struct SchemaDiffJson {
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    only_in_file1: Vec<SchemaColumnJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    only_in_file2: Vec<SchemaColumnJson>,
+}
+
+#[derive(Serialize)]
+struct DiffJsonOutput {
+    identical: bool,
+    file1: String,
+    file2: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    row_count: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    columns: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schema: Option<SchemaDiffJson>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    only_in_file1: Vec<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    only_in_file2: Vec<HashMap<String, String>>,
+    #[serde(skip_serializing_if = "is_false")]
+    truncated: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    limit: Option<usize>,
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
+}
+
+fn schema_columns(columns: &[(String, String)]) -> Vec<SchemaColumnJson> {
+    columns
+        .iter()
+        .map(|(name, data_type)| SchemaColumnJson {
+            name: name.clone(),
+            data_type: data_type.clone(),
+        })
+        .collect()
+}
+
+fn row_strings_to_objects(columns: &[String], rows: &[String]) -> Vec<HashMap<String, String>> {
+    rows.iter()
+        .map(|row| {
+            let values: Vec<&str> = row.split('\t').collect();
+            columns
+                .iter()
+                .zip(values)
+                .map(|(col, val)| (col.clone(), val.to_string()))
+                .collect()
+        })
+        .collect()
+}
+
+fn print_schema_diff_text(
+    file1: &str,
+    file2: &str,
+    only_in_file1: &[(String, String)],
+    only_in_file2: &[(String, String)],
+) {
+    eprintln!("Schema differences:");
+    if !only_in_file1.is_empty() {
+        eprintln!("  Only in {file1}:");
+        for (name, dt) in only_in_file1 {
+            eprintln!("    {name}: {dt}");
+        }
+    }
+    if !only_in_file2.is_empty() {
+        eprintln!("  Only in {file2}:");
+        for (name, dt) in only_in_file2 {
+            eprintln!("    {name}: {dt}");
+        }
+    }
+}
+
+fn print_diff_text(report: &DiffReport) {
+    if !report.schema_only_in_file1.is_empty() || !report.schema_only_in_file2.is_empty() {
+        print_schema_diff_text(
+            &report.file1,
+            &report.file2,
+            &report.schema_only_in_file1,
+            &report.schema_only_in_file2,
+        );
+    }
+
+    if report.identical {
+        let total = report.row_count.unwrap_or(0);
+        let row_label = if total == 1 { "row" } else { "rows" };
+        println!("Files are identical ({total} {row_label})");
+        return;
+    }
+
+    let header = report.columns.join("\t");
+
+    if !report.only_in_file1.is_empty() {
+        let count = report.only_in_file1.len();
+        let row_label = if count == 1 { "row" } else { "rows" };
+        println!("Only in {} ({count} {row_label}):", report.file1);
+        println!("  {header}");
+        for row_str in &report.only_in_file1 {
+            println!("  {row_str}");
+        }
+    }
+
+    if !report.only_in_file1.is_empty() && !report.only_in_file2.is_empty() {
+        println!();
+    }
+
+    if !report.only_in_file2.is_empty() {
+        let count = report.only_in_file2.len();
+        let row_label = if count == 1 { "row" } else { "rows" };
+        println!("Only in {} ({count} {row_label}):", report.file2);
+        println!("  {header}");
+        for row_str in &report.only_in_file2 {
+            println!("  {row_str}");
+        }
+    }
+
+    if report.truncated {
+        println!();
+        println!(
+            "(output truncated at {} diffs; use --limit to increase the limit)",
+            report.limit
+        );
+    }
+}
+
+fn diff_json_string(report: &DiffReport) -> eyre::Result<String> {
+    let schema = if report.schema_only_in_file1.is_empty() && report.schema_only_in_file2.is_empty()
+    {
+        None
+    } else {
+        Some(SchemaDiffJson {
+            only_in_file1: schema_columns(&report.schema_only_in_file1),
+            only_in_file2: schema_columns(&report.schema_only_in_file2),
+        })
+    };
+
+    let output = if report.identical {
+        DiffJsonOutput {
+            identical: true,
+            file1: report.file1.clone(),
+            file2: report.file2.clone(),
+            row_count: report.row_count,
+            columns: None,
+            schema: None,
+            only_in_file1: Vec::new(),
+            only_in_file2: Vec::new(),
+            truncated: false,
+            limit: None,
+        }
+    } else {
+        DiffJsonOutput {
+            identical: false,
+            file1: report.file1.clone(),
+            file2: report.file2.clone(),
+            row_count: None,
+            columns: Some(report.columns.clone()),
+            schema,
+            only_in_file1: row_strings_to_objects(&report.columns, &report.only_in_file1),
+            only_in_file2: row_strings_to_objects(&report.columns, &report.only_in_file2),
+            truncated: report.truncated,
+            limit: Some(report.limit),
+        }
+    };
+
+    Ok(serde_json::to_string(&output)?)
+}
+
+fn print_diff_json(report: &DiffReport) -> eyre::Result<()> {
+    println!("{}", diff_json_string(report)?);
+    Ok(())
 }
 
 /// Opens a lazy `RecordBatchReader` without loading all rows into memory.
@@ -110,8 +352,85 @@ fn projection_indices(
         .collect()
 }
 
+/// Schema columns present in only one of the two files.
+struct SchemaOnlyColumns {
+    file1: Vec<(String, String)>,
+    file2: Vec<(String, String)>,
+}
+
+fn build_diff_report(
+    file1: &str,
+    file2: &str,
+    schema_only: SchemaOnlyColumns,
+    common_names: &[&str],
+    counts: &HashMap<String, (i64, i64)>,
+    truncated: bool,
+    limit: usize,
+) -> DiffReport {
+    let SchemaOnlyColumns {
+        file1: schema_only_in_file1,
+        file2: schema_only_in_file2,
+    } = schema_only;
+    let columns: Vec<String> = common_names
+        .iter()
+        .map(|name| (*name).to_string())
+        .collect();
+    let all_equal = !truncated && counts.values().all(|(c1, c2)| c1 == c2);
+
+    if all_equal {
+        let total = counts.values().map(|(c1, _)| *c1).sum::<i64>() as usize;
+        return DiffReport {
+            file1: file1.to_string(),
+            file2: file2.to_string(),
+            identical: true,
+            row_count: Some(total),
+            columns,
+            schema_only_in_file1,
+            schema_only_in_file2,
+            only_in_file1: Vec::new(),
+            only_in_file2: Vec::new(),
+            truncated: false,
+            limit,
+        };
+    }
+
+    let mut only_in_file1: Vec<String> = Vec::new();
+    let mut only_in_file2: Vec<String> = Vec::new();
+
+    for (row_str, (c1, c2)) in counts {
+        if c1 > c2 {
+            for _ in 0..(c1 - c2) {
+                only_in_file1.push(row_str.clone());
+            }
+        } else if c2 > c1 {
+            for _ in 0..(c2 - c1) {
+                only_in_file2.push(row_str.clone());
+            }
+        }
+    }
+
+    only_in_file1.sort();
+    only_in_file2.sort();
+
+    DiffReport {
+        file1: file1.to_string(),
+        file2: file2.to_string(),
+        identical: false,
+        row_count: None,
+        columns,
+        schema_only_in_file1,
+        schema_only_in_file2,
+        only_in_file1,
+        only_in_file2,
+        truncated,
+        limit,
+    }
+}
+
 /// The `datu diff` command: compares two data files and reports row-level differences.
 pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
+    let output_format = args.output_format();
+
     // Step 1: resolve and validate format
     let ft1 = resolve_file_type(args.input, &args.file1)?;
     let ft2 = resolve_file_type(args.input, &args.file2)?;
@@ -150,25 +469,17 @@ pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
     let set1: std::collections::HashSet<_> = cols1.iter().cloned().collect();
     let set2: std::collections::HashSet<_> = cols2.iter().cloned().collect();
 
-    let only_in_1: Vec<_> = cols1.iter().filter(|c| !set2.contains(c)).collect();
-    let only_in_2: Vec<_> = cols2.iter().filter(|c| !set1.contains(c)).collect();
+    let schema_only_in_file1: Vec<(String, String)> = cols1
+        .iter()
+        .filter(|c| !set2.contains(c))
+        .map(|(name, dt)| (name.clone(), dt.to_string()))
+        .collect();
+    let schema_only_in_file2: Vec<(String, String)> = cols2
+        .iter()
+        .filter(|c| !set1.contains(c))
+        .map(|(name, dt)| (name.clone(), dt.to_string()))
+        .collect();
     let common: Vec<_> = cols1.iter().filter(|c| set2.contains(c)).collect();
-
-    if !only_in_1.is_empty() || !only_in_2.is_empty() {
-        eprintln!("Schema differences:");
-        if !only_in_1.is_empty() {
-            eprintln!("  Only in {}:", args.file1);
-            for (name, dt) in &only_in_1 {
-                eprintln!("    {name}: {dt}");
-            }
-        }
-        if !only_in_2.is_empty() {
-            eprintln!("  Only in {}:", args.file2);
-            for (name, dt) in &only_in_2 {
-                eprintln!("    {name}: {dt}");
-            }
-        }
-    }
 
     if common.is_empty() {
         eprintln!(
@@ -183,7 +494,7 @@ pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
     }
 
     // Step 4: precompute projection indices — only needed when schemas differ
-    let needs_projection = !only_in_1.is_empty() || !only_in_2.is_empty();
+    let needs_projection = !schema_only_in_file1.is_empty() || !schema_only_in_file2.is_empty();
     let common_names: Vec<&str> = common.iter().map(|(name, _)| name.as_str()).collect();
     let indices1 = needs_projection
         .then(|| projection_indices(&schema1, &common_names))
@@ -264,61 +575,22 @@ pub async fn diff(args: DiffArgs) -> eyre::Result<()> {
     }
 
     // Step 6: report results
-    let all_equal = !truncated && counts.values().all(|(c1, c2)| c1 == c2);
+    let report = build_diff_report(
+        &args.file1,
+        &args.file2,
+        SchemaOnlyColumns {
+            file1: schema_only_in_file1,
+            file2: schema_only_in_file2,
+        },
+        &common_names,
+        &counts,
+        truncated,
+        limit,
+    );
 
-    if all_equal {
-        let total = counts.values().map(|(c1, _)| *c1).sum::<i64>() as usize;
-        let row_label = if total == 1 { "row" } else { "rows" };
-        println!("Files are identical ({total} {row_label})");
-    } else {
-        let header = common_names.join("\t");
-
-        let mut only_file1: Vec<&String> = Vec::new();
-        let mut only_file2: Vec<&String> = Vec::new();
-
-        for (row_str, (c1, c2)) in &counts {
-            if c1 > c2 {
-                for _ in 0..(c1 - c2) {
-                    only_file1.push(row_str);
-                }
-            } else if c2 > c1 {
-                for _ in 0..(c2 - c1) {
-                    only_file2.push(row_str);
-                }
-            }
-        }
-
-        only_file1.sort();
-        only_file2.sort();
-
-        if !only_file1.is_empty() {
-            let count = only_file1.len();
-            let row_label = if count == 1 { "row" } else { "rows" };
-            println!("Only in {} ({count} {row_label}):", args.file1);
-            println!("  {header}");
-            for row_str in &only_file1 {
-                println!("  {row_str}");
-            }
-        }
-
-        if !only_file1.is_empty() && !only_file2.is_empty() {
-            println!();
-        }
-
-        if !only_file2.is_empty() {
-            let count = only_file2.len();
-            let row_label = if count == 1 { "row" } else { "rows" };
-            println!("Only in {} ({count} {row_label}):", args.file2);
-            println!("  {header}");
-            for row_str in &only_file2 {
-                println!("  {row_str}");
-            }
-        }
-
-        if truncated {
-            println!();
-            println!("(output truncated at {limit} diffs; use --limit to increase the limit)");
-        }
+    match output_format {
+        DiffOutputFormat::Text => print_diff_text(&report),
+        DiffOutputFormat::Json => print_diff_json(&report)?,
     }
 
     Ok(())
@@ -335,6 +607,8 @@ mod tests {
             input: None,
             limit: 100,
             max_diffs: None,
+            json: false,
+            output: None,
         }
     }
 
@@ -400,5 +674,79 @@ mod tests {
             ..make_args("a", "b")
         };
         assert_eq!(args.effective_limit(), 5);
+    }
+
+    #[test]
+    fn test_output_format_defaults_to_text() {
+        let args = make_args("a", "b");
+        assert_eq!(args.output_format(), DiffOutputFormat::Text);
+    }
+
+    #[test]
+    fn test_output_format_json_flag() {
+        let args = DiffArgs {
+            json: true,
+            ..make_args("a", "b")
+        };
+        assert_eq!(args.output_format(), DiffOutputFormat::Json);
+    }
+
+    #[test]
+    fn test_output_format_output_option() {
+        let args = DiffArgs {
+            output: Some(DiffOutputFormat::Json),
+            ..make_args("a", "b")
+        };
+        assert_eq!(args.output_format(), DiffOutputFormat::Json);
+    }
+
+    #[test]
+    fn test_diff_json_string_identical() {
+        let report = DiffReport {
+            file1: "a.avro".to_string(),
+            file2: "a.avro".to_string(),
+            identical: true,
+            row_count: Some(4),
+            columns: vec!["id".to_string(), "name".to_string()],
+            schema_only_in_file1: Vec::new(),
+            schema_only_in_file2: Vec::new(),
+            only_in_file1: Vec::new(),
+            only_in_file2: Vec::new(),
+            truncated: false,
+            limit: 100,
+        };
+
+        let json = diff_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["identical"], true);
+        assert_eq!(value["row_count"], 4);
+        assert_eq!(value["file1"], "a.avro");
+        assert_eq!(value["file2"], "a.avro");
+    }
+
+    #[test]
+    fn test_diff_json_string_differing() {
+        let report = DiffReport {
+            file1: "file1.avro".to_string(),
+            file2: "file2.avro".to_string(),
+            identical: false,
+            row_count: None,
+            columns: vec!["id".to_string(), "name".to_string()],
+            schema_only_in_file1: Vec::new(),
+            schema_only_in_file2: vec![("email".to_string(), "Utf8".to_string())],
+            only_in_file1: vec!["1\tfoo".to_string()],
+            only_in_file2: vec!["4\tfizz".to_string()],
+            truncated: false,
+            limit: 100,
+        };
+
+        let json = diff_json_string(&report).unwrap();
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(value["identical"], false);
+        assert_eq!(value["columns"], serde_json::json!(["id", "name"]));
+        assert_eq!(value["schema"]["only_in_file2"][0]["name"], "email");
+        assert_eq!(value["only_in_file1"][0]["name"], "foo");
+        assert_eq!(value["only_in_file2"][0]["name"], "fizz");
+        assert_eq!(value["limit"], 100);
     }
 }


### PR DESCRIPTION
## Summary

- Add `--json` and `--output json` / `-o json` options to `datu diff` for structured JSON output on stdout
- Refactor diff reporting into a shared `DiffReport` with separate text and JSON renderers
- JSON includes identical/row_count, schema differences, row-level diffs keyed by column name, and truncation metadata
- Default human-readable text output is unchanged

## Test plan

- [x] Unit tests for output format resolution and JSON serialization
- [x] Cucumber scenarios for `--json`, `--output json`, and `-o json`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`


Made with [Cursor](https://cursor.com)