### PR TITLE
Fix Dependabot alert: bump transitive rand to 0.8.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3403,9 +3403,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3582,7 +3582,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a527dbc0169051c57190487c3acd22671ab84d165213abc44066297ce6a1de6e"
 dependencies = [
  "getrandom 0.2.17",
- "rand 0.8.5",
+ "rand 0.8.6",
  "wasm-bindgen",
 ]
 


### PR DESCRIPTION
## Summary

Resolves [Dependabot alert #3](https://github.com/aisrael/datu/security/dependabot/3) (GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097) by upgrading the transitive `rand 0.8.5` dependency pulled in by `reservoir-sampling` to the patched `0.8.6`.

The direct `rand 0.9.3` dependency was already on a patched version; only the lockfile entry for the older transitive chain needed updating.

## Key changes

- `Cargo.lock`: `rand 0.8.5` → `0.8.6` (via `cargo update -p rand@0.8.5 --precise 0.8.6`)

## Test plan

- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test`


Made with [Cursor](https://cursor.com)