### PR TITLE
Release v0.3.6

### DIFF
--- a/.cursor/skills/make-release/SKILL.md
+++ b/.cursor/skills/make-release/SKILL.md
@@ -90,6 +90,8 @@ Keep prose consistent with prior entries in `CHANGELOG.md`.
 - PR title example: `Release vX.Y.Z`.
 - PR body: short summary + pointer to the new CHANGELOG section + link to full diff vs `main`.
 
+Do **NOT** mention `/tag-and-publish-release` in the release PR's description as it is an internal tool.
+
 Ensure the reported PR URL is the full GitHub URL (clickable).
 
 ## Quick reference

--- a/.cursor/skills/tag-and-publish-release/SKILL.md
+++ b/.cursor/skills/tag-and-publish-release/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: tag-and-publish-release
+description: >-
+  Creates an annotated semver git tag from Cargo.toml on main, publishes a
+  GitHub release with gh, then runs cargo publish to crates.io. Use only when
+  the user runs /tag-and-publish-release after make-release is merged: current
+  branch must be main, main must match origin/main on github.com, and the
+  working tree must be clean.
+---
+
+# Tag and publish release
+
+Run **after** the merge to `main` of the release PR that make-release opened (e.g. `release/x.y.z` → `main`). Do not use this instead of make-release.
+
+**Prerequisites:** `git`, `gh` (GitHub CLI, authenticated to GitHub.com), `cargo` (Rust toolchain), crates.io credentials (`cargo login` or `CARGO_REGISTRY_TOKEN`), `origin` pointing at a github.com repository.
+
+## 0. When to apply
+
+- Apply **only** when the user explicitly invokes `/tag-and-publish-release` (or clearly asks for this same workflow by name).
+- If any gate in §1 fails, **stop** with a short explanation; do not tag or publish.
+
+## 1. Gates (must all pass)
+
+1. **Branch:** `git branch --show-current` must be exactly `main`.
+2. **Sync with origin:** Run `git fetch origin main` and `git fetch origin --tags`. Then require `HEAD` and `origin/main` to be the **same commit**:
+
+   ```bash
+   test "$(git rev-parse HEAD)" = "$(git rev-parse origin/main)"
+   ```
+
+   If not equal, stop (user must pull/rebase or push so local `main` matches GitHub).
+3. **Remote host:** `git remote get-url origin` should reference `github.com` (ssh or https). If not, stop.
+4. **Clean tree:** `git status --porcelain` must be empty.
+
+## 2. Resolve version **V**
+
+- From `Cargo.toml`, read `[package]` `version = "x.y.z"`. Call this **V** (no leading `v`).
+- Tag name **T** = `v` + **V** (e.g. `0.3.4` → `v0.3.4`), matching the tag pattern used in make-release.
+
+## 3. Idempotency / conflicts
+
+- If **T** already exists on `origin` (`git ls-remote --tags origin "refs/tags/${T}"`), stop and report; do not create a duplicate release.
+
+## 4. Create and push the tag
+
+- Create an **annotated** tag (release metadata):
+
+  ```bash
+  git tag -a "${T}" -m "Release ${T}"
+  git push origin "${T}"
+  ```
+
+## 5. Publish the GitHub release
+
+- Create the release from the new tag (generated release notes are acceptable unless the user asked for custom notes):
+
+  ```bash
+  gh release create "${T}" --title "Release ${T}" --generate-notes
+  ```
+
+- If the project expects notes from `CHANGELOG.md` instead, use `--notes-file` with the relevant section or `--notes` with a one-line pointer to the changelog; default to `--generate-notes` when unspecified.
+
+## 6. Publish to crates.io
+
+- From the repository root (where the root `Cargo.toml` for the crate lives), run:
+
+  ```bash
+  cargo publish
+  ```
+
+- If publish fails because **V** is already on crates.io, stop and report (do not bump versions here; use make-release for a new version).
+- If authentication fails, stop; the user must run `cargo login` or set `CARGO_REGISTRY_TOKEN` per [crates.io publishing](https://doc.rust-lang.org/cargo/reference/publishing.html).
+
+## 7. Report
+
+- Echo the tag name, the pushed ref, the GitHub release URL, and confirm `cargo publish` succeeded (crate name and version **V**).
+
+## Quick reference
+
+| Check | Action if failed |
+|-------|------------------|
+| Not on `main` | Stop |
+| `HEAD` ≠ `origin/main` after fetch | Stop |
+| `origin` not github.com | Stop |
+| Dirty working tree | Stop |
+| Tag **T** already on origin | Stop |
+| `gh` not authenticated | Stop; user runs `gh auth login` |
+| `cargo publish` fails (duplicate version, etc.) | Stop; report error; version bumps belong in make-release |
+| crates.io auth missing | Stop; user runs `cargo login` or sets token |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,37 @@
 # datu Version Notes
 
-## Unreleased
+## v0.3.6
+
+### Highlights
+
+- **Concat and split commands**: New `datu concat` merges multiple input files; `datu split` partitions a file into multiple outputs.
+- **Diff command**: Renamed `--max-diffs` to `--limit` for consistency with other commands (`--max-diffs` remains supported but deprecated). Added `--json` and `--output json` for structured diff output.
+- **REPL aliasing**: `select()` and `group_by()` support `name: value` keyword syntax for column and aggregate aliases.
 
 ### Improvements
+
+- **CLI**
+  - `datu concat` and `datu split` with Cucumber coverage and pipeline support.
+  - `datu diff` uses `--limit` instead of `--max-diffs`; the old flag prints a deprecation warning.
+  - `datu diff` accepts `--json` and `--output json` for machine-readable output.
 
 - **REPL**
   - `select()` supports column/aggregate aliasing via `name: value` (and quoted `"name with space": value`) keyword syntax, e.g. `select(:foo, foo_bar: :bar, total: sum(:qty))`. Works for plain projections, global aggregates, and grouped aggregates (including `group_by` keys), and for ORC's plain-column select path.
   - `group_by()` keys can also carry their own alias (e.g. `group_by(key: :foo)`), which becomes the default output name for that key; a matching `select()` alias still takes precedence when present. `select()` may refer to the key by its underlying column or by the `group_by()` alias itself (e.g. `group_by(key: :foo) |> select(:key, total: sum(:qty))`).
 
-## v0.3.6
+- **Docs**
+  - README expanded for concat, split, diff JSON output, and REPL aliasing.
 
-### Highlights
+- **Tooling**
+  - Claude Code GitHub workflow added.
+  - Dependency updates (`rand` 0.8.6).
 
-- **Diff command**: Renamed `--max-diffs` to `--limit` for consistency with other commands. `--max-diffs` remains supported but is deprecated.
+### Changelog Stats
 
-### Improvements
-
-- **CLI**
-  - `datu diff` uses `--limit` instead of `--max-diffs`; the old flag prints a deprecation warning.
-  - README and Cucumber coverage updated for the new flag.
+- 10 commits
+- 36 files changed
+- 3516 insertions
+- 499 deletions
 
 ## v0.3.5
 


### PR DESCRIPTION
## Summary

Release **v0.3.6** — concat/split commands, diff improvements, and REPL aliasing.

### Highlights

- **Concat and split commands**: New `datu concat` merges multiple input files; `datu split` partitions a file into multiple outputs.
- **Diff command**: `--max-diffs` renamed to `--limit` (deprecated alias retained); `--json` and `--output json` for structured output.
- **REPL aliasing**: `select()` and `group_by()` support `name: value` keyword syntax for column and aggregate aliases.

See the [v0.3.6 section in CHANGELOG.md](https://github.com/aisrael/datu/blob/release/0.3.6/CHANGELOG.md#v036) for full release notes and stats (10 commits, 36 files changed).

## Test plan

- [ ] CI passes on this PR
- [ ] CHANGELOG v0.3.6 section reviewed


Made with [Cursor](https://cursor.com)