### PR TITLE
Split top-level help into Queries and Commands sections

### DIFF
--- a/features/cli/cli.feature
+++ b/features/cli/cli.feature
@@ -12,15 +12,17 @@ Feature: CLI
 
       Usage: datu [COMMAND]
 
-      Commands:
-        concat   concatenate multiple input files into a single output file
-        convert  convert between file formats
+      Queries:
         count    return the number of rows in a file
         diff     compare two data files row-by-row
         head     print the first n lines of a file
         sample   sample n random rows from a file
         tail     print the last n lines of a file
         schema   display the schema of a file
+
+      Commands:
+        concat   concatenate multiple input files into a single output file
+        convert  convert between file formats
         split    split a large input file into multiple output files of at most N rows each
         version  print the datu version
         help     Print this message or the help of the given subcommand(s)
@@ -38,15 +40,17 @@ Feature: CLI
 
       Usage: datu [COMMAND]
 
-      Commands:
-        concat   concatenate multiple input files into a single output file
-        convert  convert between file formats
+      Queries:
         count    return the number of rows in a file
         diff     compare two data files row-by-row
         head     print the first n lines of a file
         sample   sample n random rows from a file
         tail     print the last n lines of a file
         schema   display the schema of a file
+
+      Commands:
+        concat   concatenate multiple input files into a single output file
+        convert  convert between file formats
         split    split a large input file into multiple output files of at most N rows each
         version  print the datu version
         help     Print this message or the help of the given subcommand(s)

--- a/src/bin/datu/main.rs
+++ b/src/bin/datu/main.rs
@@ -54,10 +54,62 @@ pub enum Command {
     Version,
 }
 
+/// Top-level subcommand names that are read-only queries; everything else listed
+/// under the top-level `Commands:` help is treated as a mutating/creating command.
+const QUERY_COMMANDS: &[&str] = &["count", "diff", "head", "sample", "tail", "schema"];
+
+/// Builds the top-level `--help` text, splitting clap's default flat `Commands:`
+/// listing into "Queries:" and "Commands:" sections based on [`QUERY_COMMANDS`].
+fn grouped_help(cmd: &clap::Command) -> String {
+    let mut plain = cmd.clone();
+    plain = plain.color(clap::ColorChoice::Never);
+    let rendered = plain.render_help().to_string();
+
+    let lines: Vec<&str> = rendered.lines().collect();
+    let Some(heading_idx) = lines.iter().position(|line| *line == "Commands:") else {
+        return rendered;
+    };
+    let block_end = lines[heading_idx + 1..]
+        .iter()
+        .position(|line| line.trim().is_empty())
+        .map(|offset| heading_idx + 1 + offset)
+        .unwrap_or(lines.len());
+    let block = &lines[heading_idx + 1..block_end];
+
+    let mut queries = Vec::new();
+    let mut commands = Vec::new();
+    for line in block {
+        let name = line.split_whitespace().next().unwrap_or("");
+        if QUERY_COMMANDS.contains(&name) {
+            queries.push(*line);
+        } else {
+            commands.push(*line);
+        }
+    }
+
+    let mut out: Vec<&str> = Vec::new();
+    out.extend_from_slice(&lines[..heading_idx]);
+    out.push("Queries:");
+    out.extend_from_slice(&queries);
+    out.push("");
+    out.push("Commands:");
+    out.extend_from_slice(&commands);
+    out.extend_from_slice(&lines[block_end..]);
+
+    out.join("\n")
+}
+
 /// Application entry point; parses CLI args and dispatches to the appropriate command.
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    let cli = Cli::parse();
+    use clap::{CommandFactory, FromArgMatches};
+
+    let mut cmd = Cli::command();
+    let help_text = grouped_help(&cmd);
+    cmd = cmd.override_help(help_text);
+    let matches = cmd.get_matches();
+    let cli = Cli::from_arg_matches(&matches)?;
+
     match cli.command {
         None => run_repl().await,
         Some(Command::Concat(args)) => concat(args).await,


### PR DESCRIPTION
## Summary
- Groups the top-level `datu --help` subcommand listing into two sections: **Queries** (read-only: `count`, `diff`, `head`, `sample`, `tail`, `schema`) and **Commands** (mutating/file-creating: `concat`, `convert`, `split`, `version`, plus clap's auto `help`).
- clap 4.6 has no built-in way to split one flat subcommand list into multiple headings (`subcommand_help_heading` only renames the single "Commands:" heading for the whole list), so the grouped text is built by post-processing clap's own rendered help output and installing it via `Command::override_help`.
- Invocation is unchanged (`datu count`, `datu concat`, etc. work exactly as before) and per-subcommand `--help` (e.g. `datu concat --help`) is untouched.

## Test plan
- [x] `cargo build`
- [x] `cargo test` (251 passed)
- [x] `cargo clippy` (no issues)
- [x] `datu --help`, `-h`, and `help` show the grouped Queries/Commands sections
- [x] `datu concat --help` still shows normal single-page subcommand help
- [x] `datu bogus` (invalid subcommand) still shows the short usage error, unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)